### PR TITLE
fix for newer versions of mysql/mariadb

### DIFF
--- a/be-mysql.c
+++ b/be-mysql.c
@@ -72,8 +72,11 @@ void *be_mysql_init()
 	char *opt_flag;
 	int port;
 	bool ssl_enabled;	
+#if (defined(MYSQL_VERSION_ID)) && (MYSQL_VERSION_ID > 50012)
+	int reconnect = false;
+#else
 	my_bool reconnect = false;
-	
+#endif
 
 	_log(LOG_DEBUG, "}}}} MYSQL");
 


### PR DESCRIPTION
Building against MariaDB 10.4.12 on Gentoo fails with:
`be-mysql.c: In function ‘be_mysql_init’:
be-mysql.c:75:2: error: unknown type name ‘my_bool’; did you mean ‘bool’?
   75 |  my_bool reconnect = false;
      |  ^~~~~~~
      |  bool
make: *** [<builtin>: be-mysql.o] Error 1
`