### PR TITLE
Verify acl the right way

### DIFF
--- a/be-cdb.c
+++ b/be-cdb.c
@@ -113,7 +113,7 @@ int be_cdb_getuser(void *handle, const char *username, const char *password, cha
 
 /*
  * Check access to topic for username. Look values for a key "acl:username"
- * and use mosquitto_topic_matches_sub() to validate the topic.
+ * and use mosquitto_auth_sub_topic_matches_acl() to validate the topic.
  */
 
 int be_cdb_access(void *handle, const char *username, char *topic)
@@ -123,7 +123,7 @@ int be_cdb_access(void *handle, const char *username, char *topic)
 	unsigned klen;
 	int found = 0;
 	struct cdb_find cdbf;
-	bool bf;
+	int bf = FALSE;
 
 	if (!conf || !username || !topic)
 		return (0);
@@ -142,7 +142,7 @@ int be_cdb_access(void *handle, const char *username, char *topic)
 		val = malloc(vlen);
 		cdb_read(conf->cdb, val, vlen, vpos);
 
-		mosquitto_topic_matches_sub(val, topic, &bf);
+		mosquitto_auth_sub_topic_matches_acl(val, topic, &bf);
 		found |= bf;
 
 		free(val);

--- a/be-files.c
+++ b/be-files.c
@@ -358,7 +358,7 @@ static int do_aclcheck(dllist * acl_list,
 		           int access)
 {
 	char buf[512];
-	bool ret;
+	int ret = FALSE;
 	acl_entry *acl;
 	const char *t;
 	const char *si;
@@ -391,7 +391,7 @@ static int do_aclcheck(dllist * acl_list,
 			}
 		}
 		*di = '\0';
-		if (mosquitto_topic_matches_sub(buf, topic, &ret) != MOSQ_ERR_SUCCESS) {
+		if (mosquitto_auth_sub_topic_matches_acl(buf, topic, &ret) != MOSQ_ERR_SUCCESS) {
 			LOG(MOSQ_LOG_ERR, "invalid topic '%s'", buf);
 		} else if (ret && (access & acl->access) != 0) {
 			return BACKEND_ALLOW;

--- a/be-mysql.c
+++ b/be-mysql.c
@@ -319,7 +319,7 @@ int be_mysql_aclcheck(void *handle, const char *clientid, const char *username, 
 	char *query = NULL, *u = NULL, *v;
 	long ulen;
 	int match = BACKEND_DEFER;
-	bool bf;
+	int bf = FALSE;
 	MYSQL_RES *res = NULL;
 	MYSQL_ROW rowdata;
 
@@ -366,7 +366,7 @@ int be_mysql_aclcheck(void *handle, const char *clientid, const char *username, 
 
 			t_expand(clientid, username, v, &expanded);
 			if (expanded && *expanded) {
-				mosquitto_topic_matches_sub(expanded, topic, &bf);
+				mosquitto_auth_sub_topic_matches_acl(expanded, topic, &bf);
 				if (bf) match = BACKEND_ALLOW;
 				_log(LOG_DEBUG, "  mysql: topic_matches(%s, %s) == %d",
 				     expanded, v, bf);

--- a/be-postgres.c
+++ b/be-postgres.c
@@ -287,7 +287,7 @@ int be_pg_aclcheck(void *handle, const char *clientid, const char *username, con
 	struct pg_backend *conf = (struct pg_backend *)handle;
 	char *v = NULL;
 	int match = BACKEND_DEFER;
-	bool bf;
+	int bf = FALSE;
 	PGresult *res = NULL;
 
 	_log(LOG_DEBUG, "USERNAME: %s, TOPIC: %s, acc: %d", username, topic, acc);
@@ -337,7 +337,7 @@ int be_pg_aclcheck(void *handle, const char *clientid, const char *username, con
 
 			t_expand(clientid, username, v, &expanded);
 			if (expanded && *expanded) {
-				mosquitto_topic_matches_sub(expanded, topic, &bf);
+				mosquitto_auth_sub_topic_matches_acl(expanded, topic, &bf);
 				if (bf) match = BACKEND_ALLOW;
 				_log(LOG_DEBUG, "  postgres: topic_matches(%s, %s) == %d",
 				     expanded, v, bf);

--- a/be-psk.c
+++ b/be-psk.c
@@ -86,7 +86,7 @@ char *be_psk_getuser(void *handle, const char *username, const char *password, i
 
 /*
  * Check access to topic for username. Look values for a key "acl:username"
- * and use mosquitto_topic_matches_sub() to validate the topic.
+ * and use mosquitto_auth_sub_topic_matches_acl() to validate the topic.
  */
 
 int be_psk_access(void *handle, const char *username, char *topic)


### PR DESCRIPTION
Somehow MongoDB was fixed but other implementations not. Cost me a few hours to figure out.
The plugin is still deprecated but as I had a existing database which needed to be migrated, I'm stuck with it as the go plugin is currently not compilable on the compat-branch.